### PR TITLE
Add fromEd25519VerificationKey2020().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @digitalbazaar/x25519-key-agreement-key-2019 ChangeLog
 
+## 4.1.0 - 
+
+### Added
+- `fromEdKeyPair()` is now an alias for `fromEd25519VerificationKey2018()` to
+  maintain backwards compatibility. New code should use 
+  `fromEd25519VerificationKey2020()` (or whatever the latest Ed25519 suite is).
+
 ## 4.0.0 - 2021-03-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ const keyPair = await X25519KeyAgreementKey2019.from({
 });
 ```
 
-Deriving 
-
 ## Contribute
 
 See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!

--- a/lib/X25519KeyAgreementKey2019.js
+++ b/lib/X25519KeyAgreementKey2019.js
@@ -95,7 +95,15 @@ export class X25519KeyAgreementKey2019 extends LDVerifierKeyPair {
     return new X25519KeyAgreementKey2019(options);
   }
 
-  static fromEdKeyPair({keyPair}) {
+  /**
+   * Converts a keypair instance of type Ed25519VerificationKey2018 to an
+   * instance of this class.
+   * @see https://github.com/digitalbazaar/ed25519-verification-key-2018
+   *
+   * @param {Ed25519VerificationKey2018} keyPair
+   * @returns {X25519KeyAgreementKey2019}
+   */
+  static fromEd25519VerificationKey2018({keyPair}) {
     const xKey = new X25519KeyAgreementKey2019({
       controller: keyPair.controller,
       publicKeyBase58: X25519KeyAgreementKey2019
@@ -108,6 +116,45 @@ export class X25519KeyAgreementKey2019 extends LDVerifierKeyPair {
     }
 
     return xKey;
+  }
+
+  /**
+   * Converts a keypair instance of type Ed25519VerificationKey2020 to an
+   * instance of this class.
+   * @see https://github.com/digitalbazaar/ed25519-verification-key-2020
+   *
+   * @param {Ed25519VerificationKey2020} keyPair
+   * @returns {X25519KeyAgreementKey2019}
+   */
+  static fromEd25519VerificationKey2020({keyPair}) {
+    const xKey = new X25519KeyAgreementKey2019({
+      controller: keyPair.controller,
+      publicKeyBase58: X25519KeyAgreementKey2019
+        .convertFromEdPublicKey(keyPair.publicKeyMultibase.substr(1))
+    });
+
+    if(keyPair.privateKeyMultibase) {
+      xKey.privateKeyBase58 = X25519KeyAgreementKey2019
+        .convertFromEdPrivateKey(keyPair.privateKeyMultibase.substr(1));
+    }
+
+    return xKey;
+  }
+
+  /**
+   * @deprecated
+   * NOTE: This is now an alias of `fromEd25519VerificationKey2018()`, to
+   * maintain backwards compatibility. Going forward, code should be using
+   * the conversion method specific to the Ed25519 suite it's using.
+   *
+   * Converts a keypair instance of type Ed25519VerificationKey2018 to an
+   * instance of this class.
+   *
+   * @param {Ed25519VerificationKey2018} keyPair
+   * @returns {X25519KeyAgreementKey2019}
+   */
+  static fromEdKeyPair({keyPair}) {
+    return this.fromEd25519VerificationKey2018({keyPair});
   }
 
   /**


### PR DESCRIPTION
Add support for converting `Ed25519VerificationKey2020` type keys to X25519KeyAgreementKey2019.

`fromEdKeyPair()` is now an alias for `fromEd25519VerificationKey2018()` to maintain backwards compatibility. New code should use `fromEd25519VerificationKey2020()` (or whatever the latest Ed25519 suite is).