### PR TITLE
Update to use crypto-ld 5 and latest ed25519 2020.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/x25519-key-agreement-key-2019 ChangeLog
 
+## 5.0.0 -
+
+## Changed
+- Update to use `crypto-ld v5.0`.
+- **BREAKING**: Removed helper methods `addPublicKey` and `addPrivateKey`.
+
 ## 4.1.0 - 2021-03-14
 
 ### Added

--- a/lib/X25519KeyAgreementKey2019.js
+++ b/lib/X25519KeyAgreementKey2019.js
@@ -1,7 +1,7 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
-import {LDVerifierKeyPair} from 'crypto-ld';
+import {LDKeyPair} from 'crypto-ld';
 import ed2curve from 'ed2curve';
 import {encode, decode} from 'base58-universal';
 import * as nodeCrypto from './nodeCrypto.js';
@@ -10,7 +10,7 @@ import * as env from './env.js';
 
 const SUITE_ID = 'X25519KeyAgreementKey2019';
 
-export class X25519KeyAgreementKey2019 extends LDVerifierKeyPair {
+export class X25519KeyAgreementKey2019 extends LDKeyPair {
   /**
    * An implementation of x25519
    * [X25519 Key Agreement 2019]{@link https://w3c-dvcg.github.io/}
@@ -100,6 +100,7 @@ export class X25519KeyAgreementKey2019 extends LDVerifierKeyPair {
    * instance of this class.
    * @see https://github.com/digitalbazaar/ed25519-verification-key-2018
    *
+   * @typedef {Object} Ed25519VerificationKey2018
    * @param {Ed25519VerificationKey2018} keyPair
    * @returns {X25519KeyAgreementKey2019}
    */
@@ -123,6 +124,7 @@ export class X25519KeyAgreementKey2019 extends LDVerifierKeyPair {
    * instance of this class.
    * @see https://github.com/digitalbazaar/ed25519-verification-key-2020
    *
+   * @typedef {Object} Ed25519VerificationKey2020
    * @param {Ed25519VerificationKey2020} keyPair
    * @returns {X25519KeyAgreementKey2019}
    */
@@ -216,30 +218,32 @@ export class X25519KeyAgreementKey2019 extends LDVerifierKeyPair {
   }
 
   /**
-   * Adds a public key base to a public key node.
+   * Exports the serialized representation of the KeyPair.
    *
-   * @param {object} key - The public key object in a jsonld-signature.
-   * @param {string} key.publicKeyBase58 - Base58btc encoded Public Key.
+   * @param {object} [options={}] - Options hashmap.
+   * @param {boolean} [options.publicKey] - Export public key material?
+   * @param {boolean} [options.privateKey] - Export private key material?
    *
-   * @see https://github.com/digitalbazaar/jsonld-signatures
-   *
-   * @returns {object} A PublicKeyNode, with key material.
+   * @returns {object} A plain js object that's ready for serialization
+   *   (to JSON, etc), for use in DIDs etc.
    */
-  addPublicKey({key}) {
-    key.publicKeyBase58 = this.publicKeyBase58;
-    return key;
-  }
-
-  /**
-   * Adds the private key material to the KeyPair.
-   * @param {object} key - A plain object.
-   * @param {string} key.privateKeyBase58 - Base58btc encoded Private Key
-   *
-   * @return {object} The keyNode with encoded private key material.
-   */
-  addPrivateKey({key}) {
-    key.privateKeyBase58 = this.privateKeyBase58;
-    return key;
+  export({publicKey = false, privateKey = false} = {}) {
+    if(!(publicKey || privateKey)) {
+      throw new TypeError(
+        'Export requires specifying either "publicKey" or "privateKey".');
+    }
+    const exportedKey = {
+      id: this.id,
+      type: this.type,
+      controller: this.controller
+    };
+    if(publicKey) {
+      exportedKey.publicKeyBase58 = this.publicKeyBase58;
+    }
+    if(privateKey) {
+      exportedKey.privateKeyBase58 = this.privateKeyBase58;
+    }
+    return exportedKey;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/digitalbazaar/x25519-key-agreement-key-2019#readme",
   "dependencies": {
     "base58-universal": "^1.0.0",
-    "crypto-ld": "^4.0.1",
+    "crypto-ld": "^5.0.0",
     "ed2curve": "^0.3.0",
     "esm": "^3.2.25",
     "tweetnacl": "^1.0.3"
@@ -52,8 +52,8 @@
     "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.11.0",
     "@babel/runtime": "^7.11.0",
-    "@digitalbazaar/ed25519-verification-key-2018": "^2.0.0",
-    "@digitalbazaar/ed25519-verification-key-2020": "^1.0.0",
+    "@digitalbazaar/ed25519-verification-key-2018": "^3.0.0",
+    "@digitalbazaar/ed25519-verification-key-2020": "^2.0.0",
     "babel-loader": "^8.1.0",
     "chai": "^4.2.0",
     "chai-bytes": "^0.1.2",

--- a/test/X25519KeyAgreementKey2019.spec.js
+++ b/test/X25519KeyAgreementKey2019.spec.js
@@ -1,8 +1,6 @@
 /*!
- * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
-'use strict';
-
 import chai from 'chai';
 chai.should();
 const {expect} = chai;


### PR DESCRIPTION
Propagating changes to crypto-ld. See similar PR https://github.com/digitalbazaar/ed25519-verification-key-2020/pull/8.